### PR TITLE
GitHub auth fix

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: "Pull Request"
 on:
-  pull_request_review:
-    types: submitted
+  pull_request:
+  workflow_dispatch: {}
 
 jobs:
   node-test:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,34 @@
+name: "Pull Request"
+on:
+  pull_request_review:
+    types: submitted
+
+jobs:
+  node-test:
+    name: "NPM test"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '12.x'
+      - run: npm install
+      - run: npm run build
+      - run: npm test
+
+  build-test:
+    name: "Build Test"
+    needs: node-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          context: .
+          tags: burendouk/stackedit:latest

--- a/src/services/providers/helpers/githubHelper.js
+++ b/src/services/providers/helpers/githubHelper.js
@@ -89,8 +89,8 @@ export default {
     const user = (await networkSvc.request({
       method: 'GET',
       url: 'https://api.github.com/user',
-      params: {
-        access_token: accessToken,
+      headers: {
+        authorization: `token ${accessToken}`,
       },
     })).body;
     userSvc.addUserInfo({


### PR DESCRIPTION
Fixing this:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

This should allow us to host this ourselves and use it against the handbook content.